### PR TITLE
[FIX] keep select multiple dropdown when active

### DIFF
--- a/material/admin/static/admin/js/admin/RelatedObjectLookups.js
+++ b/material/admin/static/admin/js/admin/RelatedObjectLookups.js
@@ -196,6 +196,8 @@
 
     // Update dropdown on Add/Change popup close
     $(document).on('change', '.related-widget-wrapper select', function() {
-        $(this).not('.disabled').not('.material-ignore').material_select();
+        if(!$(this).siblings('input').hasClass('active')) {
+            $(this).not('.disabled').not('.material-ignore').material_select();
+        }
     });
 })(django.jQuery);


### PR DESCRIPTION
If the sibling input tag is .active it means that the user is still checking boxes, so we keep the dropdown open even if the select tag is changing (options are selected), otherwise (for example when a new object is added from an add_popup) we let material_select() refresh the option list.